### PR TITLE
refactor: :recycle: change bot message loading indicator location

### DIFF
--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -42,7 +42,12 @@ export default function ChatMessages({ isLoading, messages, stop, error }: Props
         <ChatMessage key={message.id} message={message} />
       ))}
 
-      {isLoading && <p className="p-2">...</p>}
+      {isLoading && messages[messages.length - 1].role === 'user' && (
+        <ChatMessage
+          key={'bot-message-loading'}
+          message={{ id: 'bot-message-loading', content: '...', role: 'assistant' }}
+        />
+      )}
 
       {!isLoading && !errorMessage && messages.length === 0 && (
         <p className="text-gray-400">No messages</p>


### PR DESCRIPTION
Show the "..." message loading indication now as a bot message skeleton
![image](https://github.com/kevinneuman/openai-chat/assets/26547857/00dc3655-8fc5-4cf6-8e81-6026ce67d125)
